### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/Bettman66/ioBroker.wiobrowser.git"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=16"
   },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",


### PR DESCRIPTION
adapter-core 3.x.x. is known to fail when installed at node 14 or lower as npm 6 does not install peerDependencies. So this aapter requires node 16 minimum